### PR TITLE
Test sorting of commits for path argument.

### DIFF
--- a/man/commits.Rd
+++ b/man/commits.Rd
@@ -30,7 +30,7 @@ or a branch. The default is NULL for the current branch.}
 \item{path}{The path to a file. If not NULL, only commits modifying
 this file will be returned. Note that modifying commits that
 occurred before the file was given its present name are not
-returned; that is, the output of \code{git log} with 
+returned; that is, the output of \code{git log} with
 \code{--no-follow} is reproduced.}
 }
 \value{

--- a/src/git2r_revwalk.c
+++ b/src/git2r_revwalk.c
@@ -420,7 +420,7 @@ SEXP git2r_revwalk_contributions(
     if (LOGICAL(topological)[0])
         sort_mode |= GIT_SORT_TOPOLOGICAL;
     if (LOGICAL(time)[0])
-        sort_mode = GIT_SORT_TIME | (sort_mode & GIT_SORT_REVERSE);
+        sort_mode |= GIT_SORT_TIME;
     if (LOGICAL(reverse)[0])
         sort_mode |= GIT_SORT_REVERSE;
 

--- a/tests/commits_path.R
+++ b/tests/commits_path.R
@@ -195,6 +195,7 @@ stopifnot(commits_abs[[1]]$sha == c_abs$sha)
 ## * | 7ae2fd5 commit c
 ## |/
 ## * 923f3ea commit base
+Sys.sleep(1)
 writeLines(as.character(1:100), file.path(path, "test-time.txt"))
 add(repo, "test-time.txt")
 c_base <- commit(repo, "commit base")
@@ -236,15 +237,27 @@ stopifnot(identical(
     commits(repo, topological = TRUE, time = FALSE, path = "test-time.txt"),
     list(c_merge_time, c_b, c_a, c_d, c_c, c_base)
 ))
+stopifnot(identical(
+    commits(repo, topological = TRUE, time = FALSE, path = "test-time.txt"),
+    commits(repo, topological = TRUE, time = FALSE)[1:6]
+))
 # time - commits ordered by time they were created, not merged into master
 stopifnot(identical(
     commits(repo, topological = FALSE, time = TRUE, path = "test-time.txt"),
     list(c_merge_time, c_d, c_b, c_c, c_a, c_base)
 ))
+stopifnot(identical(
+    commits(repo, topological = FALSE, time = TRUE, path = "test-time.txt"),
+    commits(repo, topological = FALSE, time = TRUE)[1:6]
+))
 # topological and time - dominated by time
 stopifnot(identical(
     commits(repo, topological = TRUE, time = TRUE, path = "test-time.txt"),
     list(c_merge_time, c_d, c_b, c_c, c_a, c_base)
+))
+stopifnot(identical(
+    commits(repo, topological = TRUE, time = TRUE, path = "test-time.txt"),
+    commits(repo, topological = TRUE, time = TRUE)[1:6]
 ))
 # reverse with topological and/or time
 stopifnot(identical(


### PR DESCRIPTION
I wrote some tests to confirm the behavior of the sorting of the commits. By creating commits in different branches, I was able to differentiate between `topological=TRUE, time=FALSE` and `topological=FALSE, time=TRUE`. However, I couldn't think of a scenario where `topological=TRUE, time=TRUE` was different from `topological=FALSE, time=TRUE`. It appears that the time sorting overrides the topological sorting. Is this the behavior we want/expect?

cc: @stewid
xref: https://github.com/ropensci/git2r/pull/372#discussion_r290593793